### PR TITLE
ieda: 0-unstable-2025-03-12 -> 0-unstable-2025-06-05

### DIFF
--- a/pkgs/ieda/glog.patch
+++ b/pkgs/ieda/glog.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1455589a2..a29966f3d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,6 +33,9 @@ option(BUILD_GUI "Enable GUI components (default OFF)" OFF)
+ option(USE_GPU "Enable GPU acceleration (default OFF)" OFF)
+ option(COMPATIBILITY_MODE "Enable compatibility mode (disable aggressive optimizations)" ON)
+ 
++# Define GLOG_USE_GLOG_EXPORT for glog 0.7.1+ compatibility
++add_definitions(-DGLOG_USE_GLOG_EXPORT)
++
+ if(NOT DEFINED CMD_BUILD)
+     set(SANITIZER OFF)
+     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
+diff --git a/src/operation/iPL/source/module/logger/CMakeLists.txt b/src/operation/iPL/source/module/logger/CMakeLists.txt
+index bb15e453f..ded7fa41c 100644
+--- a/src/operation/iPL/source/module/logger/CMakeLists.txt
++++ b/src/operation/iPL/source/module/logger/CMakeLists.txt
+@@ -1,3 +1,6 @@
++# Define GLOG_USE_GLOG_EXPORT for glog 0.7.1+ compatibility
++add_definitions(-DGLOG_USE_GLOG_EXPORT)
++
+ add_library(ipl-module-logger Log.cc)
+ 
+ target_link_directories(ipl-module-logger
+diff --git a/src/utility/log/CMakeLists.txt b/src/utility/log/CMakeLists.txt
+index e91ff9838..ce40213de 100644
+--- a/src/utility/log/CMakeLists.txt
++++ b/src/utility/log/CMakeLists.txt
+@@ -5,6 +5,9 @@ AUX_SOURCE_DIRECTORY(./ SRC)
+ 
+ SET(LINK_unwind "unwind")
+ 
++# Define GLOG_USE_GLOG_EXPORT for glog 0.7.1+ compatibility
++add_definitions(-DGLOG_USE_GLOG_EXPORT)
++
+ if(BUILD_STATIC_LIB)
+   SET(LINK_glog   "libglog.a")
+   SET(LINK_gflags "libgflags.a")


### PR DESCRIPTION
* Update version to 0-unstable-2025-06-05
* Add fetchSubmodules flag to fetchgit
* Add patch to disable failing iCTS tests on aarch64
* Add multiple patches to fix build errors and compatibility issues
* Add glog.patch for glog 0.7.1+ compatibility
* Remove custom glog override and use upstream version